### PR TITLE
Updates to use H2 in-memory DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,6 @@ Microservice to return the details of the nearest Job Centre Plus for a given po
 
 * Java 8
 * Maven
-* Docker (for postgresql)
-
-## DB
-### Local DB
-
-The easiest way to have a local DB up and running on your machine is to use docker
-```bash
-$ docker run --name dwp-jsa -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dwp-jsa -p5432:5432 postgres
-```
 
 ## PublicKey
 
@@ -35,9 +26,11 @@ java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n \
 
 # Dependencies
 
-This service requires nsjsa-commons to build.
+This service requires nsjsa-commons to build
+https://github.com/dwp/nsjsa-commons
 
 ## Sample dataset
 
-src/test/resources/test-data.sql contains a sample data set that can be uploaded into
-the postgres database.
+src/main/resources/data.sql contains a sample data set that will be uploaded into
+the H2 database at the startup of the application. 
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project 
-    xmlns="http://maven.apache.org/POM/4.0.0" 
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.dwp.jsa</groupId>
@@ -61,14 +61,14 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/dwp/jsa/officesearch/service/models/db/PhoneNumber.java
+++ b/src/main/java/uk/gov/dwp/jsa/officesearch/service/models/db/PhoneNumber.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.jsa.officesearch.service.models.db;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.Column;
@@ -21,6 +22,7 @@ public class PhoneNumber {
     @GeneratedValue(generator = "UUID")
     @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
     @Column(name = "id", updatable = false, nullable = false, unique = true)
+    @Type(type = "uuid-char")
     private UUID phoneNumberId;
     private String number;
     private String type;

--- a/src/main/java/uk/gov/dwp/jsa/officesearch/service/models/db/PostcodeCovered.java
+++ b/src/main/java/uk/gov/dwp/jsa/officesearch/service/models/db/PostcodeCovered.java
@@ -2,6 +2,7 @@ package uk.gov.dwp.jsa.officesearch.service.models.db;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.Column;
@@ -23,6 +24,7 @@ public class PostcodeCovered {
     @GeneratedValue(generator = "UUID")
     @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
     @Column(name = "id", updatable = false, nullable = false, unique = true)
+    @Type(type = "uuid-char")
     private UUID postcodeCoveredId;
     private String postcodeZone;
     @CreationTimestamp

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,8 +14,8 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.datasource.url=${office_search.db.url}
 spring.datasource.username=${office_search.db.login}
 spring.datasource.password=${office_search.db.password}
-spring.jpa.properties.hibernate.default_schema=${office_search.db.schema}
-spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 app.version=1
 
@@ -31,9 +31,9 @@ logging.level.root=INFO
 logging.level.org.springframework.web=ERROR
 logging.level.org.hibernate=ERROR
 
-office_search.db.url=jdbc:postgresql://localhost:5432/dwp-jsa
-office_search.db.login=office_search_db_user
-office_search.db.password=mypassword
+office_search.db.url=jdbc:h2:mem:${office_search.db.schema}
+office_search.db.login=sa
+office_search.db.password=password
 office_search.db.schema=office_search_schema
 
 server.port=8800

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,37 @@
+INSERT INTO benefit_centre (dwp_bc_id, dwp_service_id, name, created_timestamp, updated_timestamp) VALUES (101810, 'JSGQ', 'London Benefit Centre', '2018-12-11 10:33:44.520069', '2018-12-11 10:33:44.520069');
+
+INSERT INTO job_centre (dwp_jcp_id, dwp_bc_id, name, first_line, second_line, town, postcode, created_timestamp, updated_timestamp) VALUES (207610, 101810, 'St Marylebone Jobcentre', '26-46 Lisson Grove', null, 'London', 'NW1 6TZ', '2018-12-11 10:36:06.944262', '2018-12-11 10:36:06.944262');
+
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('87ef9862-b650-4652-92de-efb16f1b94d8', 207610, 'SW1A', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('cc9a115c-95d8-47df-b60d-9e1a4369586f', 207610, 'NW8', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('76a3582a-9132-499d-93eb-f3abefa13555', 207610, 'W1A', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('6fd45b4b-ead4-4622-87f2-80a3ab4c2574', 207610, 'NW1 1', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('a7cb4d3b-2550-4723-90bb-6f68068ba9d4', 207610, 'W2', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('1b1f28a7-3049-4169-b842-06ac01c43b3a', 207610, 'WC2A', '2018-12-13 11:55:03.118329', '2018-12-13 11:55:03.118329');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('75b9260b-dfc4-478b-bb27-c69c13a5b826', 207610, 'W9 1', '2018-12-13 11:59:02.941935', '2018-12-13 11:59:02.941935');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('4b9e71b2-523b-4595-971a-64e450dea2d2', 207610, 'NW1 2', '2018-12-13 11:59:02.941935', '2018-12-13 11:59:02.941935');
+
+INSERT INTO phone_number (id, number, type, created_timestamp, updated_timestamp) VALUES ('c934469e-98ee-45be-818f-b4e19ca5077a', '0800 169 0190', 'main board', '2018-12-11 10:37:22.821943', '2018-12-11 10:37:22.821943');
+INSERT INTO phone_number (id, number, type, created_timestamp, updated_timestamp) VALUES ('06b88be5-ac5e-475c-965d-9a235445219b', '0800 169 0207', 'welsh', '2018-12-11 14:09:37.861606', '2018-12-11 14:09:37.861606');
+
+INSERT INTO jcp_number (dwp_jcp_id, phone_number_id) VALUES (207610, 'c934469e-98ee-45be-818f-b4e19ca5077a');
+INSERT INTO jcp_number (dwp_jcp_id, phone_number_id) VALUES (207610, '06b88be5-ac5e-475c-965d-9a235445219b');
+
+
+
+INSERT INTO job_centre (dwp_jcp_id, dwp_bc_id, name, first_line, second_line, town, postcode, created_timestamp, updated_timestamp) VALUES (301106, 101810, 'Kentish Town Jobcentre', '178 Kentish Town Road', 'Kentish Town', 'London', 'NW5 2AG', '2018-12-13 13:38:40.636931', '2018-12-13 13:38:40.636931');
+
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('2bac625c-e35f-4985-9539-eda3d4e5ac6d', 301106, 'NW1 0', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('216ce1fc-c603-4dd3-ab68-a4d893369e52', 301106, 'NW1 7', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('420e1abe-397a-41a2-8b6f-f776ba9da6b7', 301106, 'NW1 8', '2018-12-13 11:59:02.941935', '2018-12-13 11:59:02.941935');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('5f16ed5b-68ee-4d71-92f4-7c106552016b', 301106, 'NW1 9', '2018-12-13 11:59:02.941935', '2018-12-13 11:59:02.941935');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('53b42f6b1-9e1f-4b24-bbd4-282a28ad7d29', 301106, 'NW3', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('66d79814-0a56-4382-af88-ace0093307b8', 301106, 'NW5', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('96f57782-1d3c-42db-b847-94b0de37bb05', 301106, 'NW6 3', '2018-12-11 10:41:46.585808', '2018-12-11 10:41:46.585808');
+INSERT INTO postcode_covered (id, dwp_jcp_id, postcode_zone, created_timestamp, updated_timestamp) VALUES ('428f6c54-3e42-40f7-86b5-4354a73c9b8a', 301106, 'NW6 4', '2018-12-13 11:55:03.118329', '2018-12-13 11:55:03.118329');
+
+INSERT INTO phone_number (id, number, type, created_timestamp, updated_timestamp) VALUES ('b062a679-0fe0-4eae-b3d4-9fa70227a2af', '0800 169 0190', 'main board', '2018-12-11 10:37:22.821943', '2018-12-11 10:37:22.821943');
+INSERT INTO phone_number (id, number, type, created_timestamp, updated_timestamp) VALUES ('24fd2d4d-894d-42bd-a719-69047c398e79', '0800 169 0207', 'welsh', '2018-12-11 14:09:37.861606', '2018-12-11 14:09:37.861606');
+
+INSERT INTO jcp_number (dwp_jcp_id, phone_number_id) VALUES (301106, 'b062a679-0fe0-4eae-b3d4-9fa70227a2af');
+INSERT INTO jcp_number (dwp_jcp_id, phone_number_id) VALUES (301106, '24fd2d4d-894d-42bd-a719-69047c398e79');


### PR DESCRIPTION
This includes the following changes
- Removed postgres DB
- Added support for H2 in-memory DB
- Updated README for pivoting to H2 in memory database

We have moved to H2 database to remove the dependency on
Postgres database as the data for office search is static.
Data will be inserted at the server start up of the Spring boot
app.